### PR TITLE
Fix ingress annotations for load balancing

### DIFF
--- a/helm_deploy/manage-my-prison/values.yaml
+++ b/helm_deploy/manage-my-prison/values.yaml
@@ -15,7 +15,7 @@ generic-service:
     tlsSecretName: manage-my-prison-cert
     path: /
     annotations:
-      external-dns.alpha.kubernetes.io/aws-weight: "0"
+      external-dns.alpha.kubernetes.io/aws-weight: "100"
 
   livenessProbe:
     httpGet:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -4,6 +4,8 @@ generic-service:
 
   ingress:
     host: manage-my-prison-dev.prison.service.justice.gov.uk
+    annotations:
+      external-dns.alpha.kubernetes.io/set-identifier: manage-my-prison-dev-green
 
   env:
     INGRESS_URL: "https://manage-my-prison-dev.prison.service.justice.gov.uk"


### PR DESCRIPTION
In fact the weight should be 100 to indicate that _this_ ingress should receive all traffic.
Additionally, a name must be set to identify this ingress uniquely to R53 (i.e. needs to be different per-environment)