### PR TITLE
Configure K8s ingress

### DIFF
--- a/helm_deploy/manage-my-prison/values.yaml
+++ b/helm_deploy/manage-my-prison/values.yaml
@@ -12,7 +12,7 @@ generic-service:
   ingress:
     enabled: true
     host: app-hostname.local    # override per environment
-    tlsSecretName: manage-my-prison-cert
+    tlsSecretName: cert
     path: /
     annotations:
       external-dns.alpha.kubernetes.io/aws-weight: "100"

--- a/helm_deploy/manage-my-prison/values.yaml
+++ b/helm_deploy/manage-my-prison/values.yaml
@@ -49,12 +49,13 @@ generic-service:
       REDIS_AUTH_TOKEN: "auth_token"
 
   allowlist:
-    office: "217.33.148.210/32"
+    digital-studio: "217.33.148.210/32"
+    102pf: "213.121.161.112/28"
     health-kick: "35.177.252.195/32"
     mojvpn: "81.134.202.29/32"
-    cloudplatform-live1-1: "35.178.209.113/32"
-    cloudplatform-live1-2: "3.8.51.207/32"
-    cloudplatform-live1-3: "35.177.252.54/32"
+    # cloudplatform-live1-1: "35.178.209.113/32"
+    # cloudplatform-live1-2: "3.8.51.207/32"
+    # cloudplatform-live1-3: "35.177.252.54/32"
 
 generic-prometheus-alerts:
   targetApplication: manage-my-prison

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -5,7 +5,7 @@ generic-service:
   ingress:
     host: manage-my-prison-dev.prison.service.justice.gov.uk
     annotations:
-      external-dns.alpha.kubernetes.io/set-identifier: manage-my-prison-dev-green
+      external-dns.alpha.kubernetes.io/set-identifier: manage-my-prison-manage-my-prison-dev-green
 
   env:
     INGRESS_URL: "https://manage-my-prison-dev.prison.service.justice.gov.uk"


### PR DESCRIPTION
• Use correct TLS certificate secret
• Annotate ingress following enforced naming policy
• Tweak IP address restrictions: allow 102PF wifi and remove Cloud Platform `live-1` egresses (neither cluster is expected to need to access this app)