### PR TITLE
Configure infrastructure

### DIFF
--- a/helm_deploy/manage-my-prison/Chart.yaml
+++ b/helm_deploy/manage-my-prison/Chart.yaml
@@ -5,8 +5,8 @@ name: manage-my-prison
 version: 0.2.0
 dependencies:
   - name: generic-service
-    version: 1.0.10
+    version: 1.0.12
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 0.1.4
+    version: 0.1.5
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/helm_deploy/manage-my-prison/values.yaml
+++ b/helm_deploy/manage-my-prison/values.yaml
@@ -25,6 +25,8 @@ generic-service:
     httpGet:
       path: /ping
 
+  serviceAccountName: pod-internal
+
   # Environment variables to load into the deployment
   env:
     NODE_ENV: "production"

--- a/helm_deploy/manage-my-prison/values.yaml
+++ b/helm_deploy/manage-my-prison/values.yaml
@@ -16,6 +16,14 @@ generic-service:
     path: /
     annotations:
       external-dns.alpha.kubernetes.io/aws-weight: "100"
+      nginx.ingress.kubernetes.io/server-snippet: |
+        more_set_headers "Server: manage-my-prison";
+        more_set_headers "Permissions-Policy: interest-cohort=()"
+        more_set_headers "Referrer-Policy: same-origin";
+        more_set_headers "Strict-Transport-Security: \"max-age=31536000; includeSubdomains\"";
+        more_set_headers "X-Content-Type-Options: nosniff";
+        more_set_headers "X-Frame-Options: sameorigin";
+        more_set_headers "X-XSS-Protection: \"1; mode=block\"";
 
   livenessProbe:
     httpGet:


### PR DESCRIPTION
• Use latest HMPPS helm charts
• Attach `pod-internal` service account to allow pods to access a particular k8s secret (thereby permitting access to an S3 bucket)
• Add security-enforcing HTTP response headers at the ingress level