### PR TITLE
Make helm deployment fail if maintenance mode is incorrectly enabled

### DIFF
--- a/helm_deploy/manage-my-prison/templates/maintenance-mode/service.yaml
+++ b/helm_deploy/manage-my-prison/templates/maintenance-mode/service.yaml
@@ -6,6 +6,9 @@ Notes:
 - turned on by setting `maintenanceMode` to true
 - `generic-service.service.enabled` MUST be set to false because this service uses the same name and selector labels
 */}}
+{{- if index .Values "generic-service" "service" "enabled" -}}
+  {{ fail "`maintenanceMode` and `generic-service.service.enabled` cannot both be true!" }}
+{{- end -}}
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
Values `maintenanceMode` and `generic-service.service.enabled` cannot both be set to true: otherwise two services with the same name would be created. This is impossible and it's likely that whichever is rendered last will end up being the deployed version.
This change forces the template rendering to fail in such instances.