### PR TITLE
Give constant name to Athena setup k8s job

### DIFF
--- a/helm_deploy/manage-my-prison/templates/athena/job.yaml
+++ b/helm_deploy/manage-my-prison/templates/athena/job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: athena-setup-{{ .Release.Revision }}
+  name: setup-athena-tables
   labels:
     {{- include "manage-my-prison.labels" . | nindent 4 }}
   annotations:


### PR DESCRIPTION
… so that each release replaces the old one properly without leaving completed jobs/pods lying around