### PR TITLE
Fix caching step in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,9 @@ jobs:
             - build-info.json
             - build
             - dist
+      - persist_to_workspace:
+          root: ..
+          paths:
             - .cache/Cypress
 
   check_outdated:


### PR DESCRIPTION
`.cache` folder (where node downloads binaries like Cypress and node-gyp) actually exists in the CircleCI user's home folder, one up from the working directory where the app is checked out