### PR TITLE
Use node16 LTS version as CircleCI executor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,12 +15,12 @@ parameters:
 
   node-version:
     type: string
-    default: 16.12-browsers
+    default: 16.13-browsers
 
 executors:
   integration-tests:
     docker:
-      - image: cimg/node:16.12-browsers
+      - image: cimg/node:16.13-browsers
       - image: bitnami/redis:5.0
         environment:
           ALLOW_EMPTY_PASSWORD: yes


### PR DESCRIPTION
…now that it has been released