### PR TITLE
Improve type-checking

### DIFF
--- a/bin/record-build-info.ts
+++ b/bin/record-build-info.ts
@@ -5,8 +5,9 @@ import { resolve } from 'path'
 const target = resolve(process.cwd(), 'build-info.json')
 
 function getEnvironmentVariable(name: string): string {
-  if (process.env[name]) {
-    return process.env[name]
+  const value = process.env[name]
+  if (value) {
+    return value
   }
   throw new Error(`Missing env var ${name}`)
 }

--- a/server/config.ts
+++ b/server/config.ts
@@ -3,8 +3,9 @@ import 'dotenv/config'
 const production = process.env.NODE_ENV === 'production'
 
 function get<T>(name: string, fallback: T, options = { requireInProduction: false }): T | string {
-  if (process.env[name]) {
-    return process.env[name]
+  const value = process.env[name]
+  if (value) {
+    return value
   }
   if (fallback !== undefined && (!production || !options.requireInProduction)) {
     return fallback

--- a/server/data/athenaClient.ts
+++ b/server/data/athenaClient.ts
@@ -23,7 +23,7 @@ export default class AthenaClient {
 
   database: string
 
-  static isConfigSufficient(config: AthenaConfig): boolean {
+  static isConfigSufficient(config: Partial<AthenaConfig>): config is AthenaConfig {
     return Boolean(config.accessKeyId && config.secretAccessKey && config.workGroup && config.database)
   }
 

--- a/server/data/athenaClient.ts
+++ b/server/data/athenaClient.ts
@@ -62,7 +62,7 @@ export default class AthenaClient {
       QueryExecutionId: id,
     })
     const response = await this.athena.send(command)
-    return response.QueryExecution.Status.State as QueryExecutionState
+    return response.QueryExecution?.Status?.State as QueryExecutionState
   }
 
   /**
@@ -87,7 +87,7 @@ export default class AthenaClient {
   /**
    * Yields rows from an execution’s results
    */
-  async *executionResults(id: string): AsyncGenerator<string[]> {
+  async *executionResults(id: string): AsyncGenerator<string[], void, void> {
     let nextToken: string | undefined
     do {
       const command = new GetQueryResultsCommand({
@@ -98,10 +98,11 @@ export default class AthenaClient {
       // eslint-disable-next-line no-await-in-loop
       const response = await this.athena.send(command)
       nextToken = response.NextToken
-      const rows = response.ResultSet.Rows || []
+      const rows = response.ResultSet?.Rows || []
       // eslint-disable-next-line no-restricted-syntax
       for (const row of rows) {
-        yield row.Data.map(datum => datum.VarCharValue)
+        const data = row.Data || []
+        yield data.map(datum => datum.VarCharValue)
       }
     } while (nextToken)
   }

--- a/server/data/restClient.test.ts
+++ b/server/data/restClient.test.ts
@@ -1,0 +1,62 @@
+import nock from 'nock'
+
+import RestClient from './restClient'
+import { AgentConfig } from '../config'
+import { overrideLoggerAsync } from '../../logger'
+
+describe('restClient', () => {
+  const fakeApiUrl = 'http://localhost:8000/test'
+  const fakeToken = 'token-12345'
+  const fakeResponse = ['a', 'b', 'c']
+
+  let fakeApi: nock.Scope
+  let restClient: RestClient
+
+  beforeEach(() => {
+    fakeApi = nock(fakeApiUrl)
+    restClient = new RestClient(
+      'Test client',
+      {
+        agent: new AgentConfig(),
+        timeout: { deadline: 0, response: 0 },
+        url: fakeApiUrl,
+      },
+      fakeToken
+    )
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+    nock.cleanAll()
+  })
+
+  describe.each([
+    ['sends a request with access token', {}],
+    ['sends a request with path and access token', { path: '' }],
+  ])('get()', (name: string, params: { path?: string }) => {
+    it(name, async () => {
+      fakeApi
+        .get(params.path || '')
+        .matchHeader('authorization', `Bearer ${fakeToken}`)
+        .reply(200, fakeResponse)
+
+      const response = overrideLoggerAsync(() => restClient.get(params))
+      await expect(response).resolves.toEqual(fakeResponse)
+    })
+  })
+
+  describe.each([
+    ['sends a request with access token', {}],
+    ['sends a request with path and access token', { path: '' }],
+  ])('post()', (name: string, params: { path?: string }) => {
+    it(name, async () => {
+      fakeApi
+        .post(params.path || '')
+        .matchHeader('authorization', `Bearer ${fakeToken}`)
+        .reply(200, fakeResponse)
+
+      const response = overrideLoggerAsync(() => restClient.post(params))
+      await expect(response).resolves.toEqual(fakeResponse)
+    })
+  })
+})

--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -8,7 +8,7 @@ import { ApiConfig } from '../config'
 import type { UnsanitisedError } from '../sanitisedError'
 
 interface GetRequest {
-  path?: string
+  path: string
   query?: string
   headers?: Record<string, string>
   responseType?: string
@@ -16,7 +16,7 @@ interface GetRequest {
 }
 
 interface PostRequest {
-  path?: string
+  path: string
   headers?: Record<string, string>
   responseType?: string
   data?: Record<string, unknown>
@@ -24,7 +24,7 @@ interface PostRequest {
 }
 
 interface StreamRequest {
-  path?: string
+  path: string
   headers?: Record<string, string>
   errorLogger?: (e: UnsanitisedError) => void
 }
@@ -44,7 +44,7 @@ export default class RestClient {
     return this.config.timeout
   }
 
-  async get({ path = null, query = '', headers = {}, responseType = '', raw = false }: GetRequest): Promise<unknown> {
+  async get({ path, query = '', headers = {}, responseType = '', raw = false }: GetRequest): Promise<unknown> {
     logger.info(`Get using user credentials: calling ${this.name}: ${path} ${query}`)
     try {
       const result = await superagent
@@ -68,13 +68,7 @@ export default class RestClient {
     }
   }
 
-  async post({
-    path = null,
-    headers = {},
-    responseType = '',
-    data = {},
-    raw = false,
-  }: PostRequest = {}): Promise<unknown> {
+  async post({ path, headers = {}, responseType = '', data = {}, raw = false }: PostRequest): Promise<unknown> {
     logger.info(`Post using user credentials: calling ${this.name}: ${path}`)
     try {
       const result = await superagent
@@ -98,7 +92,7 @@ export default class RestClient {
     }
   }
 
-  async stream({ path = null, headers = {} }: StreamRequest = {}): Promise<unknown> {
+  async stream({ path, headers = {} }: StreamRequest): Promise<unknown> {
     logger.info(`Get using user credentials: calling ${this.name}: ${path}`)
     return new Promise((resolve, reject) => {
       superagent

--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -2,10 +2,10 @@ import superagent from 'superagent'
 import Agent, { HttpsAgent } from 'agentkeepalive'
 import { Readable } from 'stream'
 
-import logger from '../../logger'
-import sanitiseError from '../sanitisedError'
 import { ApiConfig } from '../config'
+import sanitiseError from '../sanitisedError'
 import type { UnsanitisedError } from '../sanitisedError'
+import logger from '../../logger'
 
 interface GetRequest {
   path: string
@@ -62,7 +62,7 @@ export default class RestClient {
 
       return raw ? result : result.body
     } catch (error) {
-      const sanitisedError = sanitiseError(error)
+      const sanitisedError = sanitiseError(error as UnsanitisedError)
       logger.warn({ ...sanitisedError, query }, `Error calling ${this.name}, path: '${path}', verb: 'GET'`)
       throw sanitisedError
     }
@@ -86,7 +86,7 @@ export default class RestClient {
 
       return raw ? result : result.body
     } catch (error) {
-      const sanitisedError = sanitiseError(error)
+      const sanitisedError = sanitiseError(error as UnsanitisedError)
       logger.warn({ ...sanitisedError }, `Error calling ${this.name}, path: '${path}', verb: 'POST'`)
       throw sanitisedError
     }

--- a/server/data/s3Client.ts
+++ b/server/data/s3Client.ts
@@ -75,7 +75,7 @@ export default class S3Client {
 
   async listObjects(prefix?: string): Promise<string[]> {
     let nextToken: string | undefined
-    const objects = []
+    const objects: string[] = []
     do {
       const command = new ListObjectsV2Command({
         Bucket: this.bucket,
@@ -84,7 +84,8 @@ export default class S3Client {
       })
       // eslint-disable-next-line no-await-in-loop
       const response = await this.s3.send(command)
-      const results = response.Contents.map(object => object.Key)
+      const contents = response.Contents || []
+      const results = contents.map(object => object.Key)
       nextToken = response.NextContinuationToken
       objects.push(...results)
     } while (nextToken)
@@ -97,7 +98,7 @@ export default class S3Client {
     const records: Uint8Array[] = []
     // eslint-disable-next-line no-restricted-syntax
     for await (const event of response.Payload) {
-      if (event.Records) {
+      if (event.Records?.Payload) {
         records.push(event.Records.Payload)
       }
     }

--- a/server/data/tokenStore.test.ts
+++ b/server/data/tokenStore.test.ts
@@ -27,6 +27,8 @@ describe('tokenStore', () => {
   })
 
   it('Can set token', async () => {
+    redisClient.set.mockImplementation((key, value, mode, duration, callback) => callback(null, 'OK'))
+
     await tokenStore.setToken('user-1', 'token-1', 10)
 
     expect(redisClient.set).toHaveBeenCalledWith('user-1', 'token-1', 'EX', 10, expect.any(Function))

--- a/server/data/tokenStore.ts
+++ b/server/data/tokenStore.ts
@@ -29,7 +29,7 @@ export default class TokenStore {
   }
 
   public async setToken(key: string, token: string, durationSeconds: number): Promise<void> {
-    this.setRedisAsync(key, token, 'EX', durationSeconds)
+    await this.setRedisAsync(key, token, 'EX', durationSeconds)
   }
 
   public async getToken(key: string): Promise<string | null> {

--- a/server/data/tokenStore.ts
+++ b/server/data/tokenStore.ts
@@ -15,7 +15,7 @@ const createRedisClient = () => {
 }
 
 export default class TokenStore {
-  private getRedisAsync: (key: string) => Promise<string>
+  private getRedisAsync: (key: string) => Promise<string | null>
 
   private setRedisAsync: (key: string, value: string, mode: string, durationSeconds: number) => Promise<void>
 
@@ -32,7 +32,7 @@ export default class TokenStore {
     this.setRedisAsync(key, token, 'EX', durationSeconds)
   }
 
-  public async getToken(key: string): Promise<string> {
+  public async getToken(key: string): Promise<string | null> {
     return this.getRedisAsync(key)
   }
 }

--- a/server/data/tokenVerification.ts
+++ b/server/data/tokenVerification.ts
@@ -1,7 +1,9 @@
 import superagent from 'superagent'
 import type { Request } from 'express'
-import getSanitisedError from '../sanitisedError'
+
 import config from '../config'
+import getSanitisedError from '../sanitisedError'
+import type { UnsanitisedError } from '../sanitisedError'
 import logger from '../../logger'
 
 function getApiClientToken(token: string) {
@@ -10,7 +12,7 @@ function getApiClientToken(token: string) {
     .auth(token, { type: 'bearer' })
     .timeout(config.apis.tokenVerification.timeout)
     .then(response => Boolean(response.body && response.body.active))
-    .catch(error => {
+    .catch((error: UnsanitisedError) => {
       logger.error(getSanitisedError(error), 'Error calling tokenVerificationApi')
     })
 }

--- a/server/sanitisedError.ts
+++ b/server/sanitisedError.ts
@@ -5,7 +5,7 @@ interface SanitisedError {
   status?: number
   headers?: unknown
   data?: unknown
-  stack: string
+  stack?: string
   message: string
 }
 

--- a/server/utils/azureAppInsights.ts
+++ b/server/utils/azureAppInsights.ts
@@ -25,7 +25,7 @@ export function initialiseAppInsights(): void {
   }
 }
 
-export function buildAppInsightsClient(name = defaultName()): TelemetryClient {
+export function buildAppInsightsClient(name = defaultName()): TelemetryClient | null {
   if (process.env.APPINSIGHTS_INSTRUMENTATIONKEY) {
     defaultClient.context.tags['ai.cloud.role'] = name
     defaultClient.context.tags['ai.application.ver'] = version()


### PR DESCRIPTION
By turning on "strict" type checking, many issues with type labelling are revealed and not all are fixed in this PR. If type definitions are to be relied upon, they ought to be correct.

Most of the changes here are just type labels (i.e. resulting javascript is unchanged) with the exception of:

- token persistence in redis: the derived promise is now awaited
- rest client: the `path` parameter is always required when GET-ing or POST-ing