### PR TITLE
Place build-info JSON in the app root even in built/compiled/Docker form of the app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ FROM base
 COPY --from=build --chown=appuser:appgroup \
     /app/package.json \
     /app/package-lock.json \
+    /app/build-info.json \
     ./
 COPY --from=build --chown=appuser:appgroup \
     /app/assets ./assets
@@ -57,8 +58,6 @@ COPY --from=build --chown=appuser:appgroup \
 # TODO: is it safer to make node_modules read-only?
 COPY --from=build --chown=appuser:appgroup \
     /app/node_modules ./node_modules
-COPY --from=build --chown=appuser:appgroup \
-    /app/build-info.json ./dist/build-info.json
 
 EXPOSE 3000
 ENV NODE_ENV='production'

--- a/server/applicationVersion.ts
+++ b/server/applicationVersion.ts
@@ -1,9 +1,9 @@
 // eslint-disable import/no-unresolved,global-require
 import fs from 'fs'
 
-const packageData = JSON.parse(fs.readFileSync('./package.json').toString())
+const packageData = JSON.parse(fs.readFileSync('./package.json', { encoding: 'utf8' }))
 const { buildNumber, gitRef } = fs.existsSync('./build-info.json')
-  ? JSON.parse(fs.readFileSync('./build-info.json').toString())
+  ? JSON.parse(fs.readFileSync('./build-info.json', { encoding: 'utf8' }))
   : {
       buildNumber: packageData.version,
       gitRef: 'unknown',

--- a/server/services/healthCheck.ts
+++ b/server/services/healthCheck.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'fs'
+
 import { serviceCheckFactory } from '../data/healthCheck'
 import config from '../config'
 import type { AgentConfig } from '../config'
@@ -37,8 +39,8 @@ function addAppInfo(result: HealthCheckResult): HealthCheckResult {
 
 function getBuild() {
   try {
-    // eslint-disable-next-line global-require
-    return require('../../build-info.json')
+    const buildInfo = readFileSync('./build-info.json', { encoding: 'utf8' })
+    return JSON.parse(buildInfo)
   } catch (ex) {
     return null
   }


### PR DESCRIPTION
…and avoid using `require` to import it to be more compatible with ESM (node cannot import JSON in ESM mode)