### PR TITLE
Add NOMIS roles api to suite of supporting services for running locally

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -5,7 +5,7 @@ services:
     image: 'bitnami/redis:5.0'
     networks:
       - hmpps_int
-    container_name: redis
+    container_name: mmp-redis
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
     ports:
@@ -15,7 +15,7 @@ services:
     image: rodolpheche/wiremock
     networks:
     - hmpps_int
-    container_name: wiremock
+    container_name: mmp-wiremock
     restart: always
     ports:
       - '9091:8080'
@@ -25,7 +25,7 @@ services:
     command: server --console-address :9001 /data
     networks:
       - hmpps_int
-    container_name: minio
+    container_name: mmp-minio
     restart: always
     environment:
       - MINIO_REGION_NAME=eu-west-2
@@ -39,7 +39,7 @@ services:
     image: minio/mc
     networks:
       - hmpps_int
-    container_name: minio-init
+    container_name: mmp-minio-init
     depends_on:
       - minio
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,18 +11,34 @@ services:
     ports:
       - '6379:6379'
 
+  nomis-user-roles-api:
+    image: quay.io/hmpps/nomis-user-roles-api:latest
+    networks:
+      - hmpps
+    container_name: nomis-user-roles-api
+    ports:
+      - '8102:8080'
+    healthcheck:
+      test: ['CMD', 'curl', '-f', 'http://localhost:8080/health/ping']
+    environment:
+      - SERVER_PORT=8080
+      - SPRING_PROFILES_ACTIVE=dev
+      - API_BASE_URL_OAUTH=http://hmpps-auth:8080/auth
+
   hmpps-auth:
     image: quay.io/hmpps/hmpps-auth:latest
     networks:
       - hmpps
     container_name: hmpps-auth
+    depends_on: [nomis-user-roles-api]
     ports:
       - '9090:8080'
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:8080/auth/health']
     environment:
-      - SPRING_PROFILES_ACTIVE=dev
+      - SPRING_PROFILES_ACTIVE=dev,nomis
       - APPLICATION_AUTHENTICATION_UI_ALLOWLIST=0.0.0.0/0
+      - NOMIS_ENDPOINT_URL=http://nomis-user-roles-api:8080
 
   minio:
     image: minio/minio

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: 'bitnami/redis:5.0'
     networks:
       - hmpps
-    container_name: redis
+    container_name: mmp-redis
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
     ports:
@@ -15,7 +15,7 @@ services:
     image: quay.io/hmpps/nomis-user-roles-api:latest
     networks:
       - hmpps
-    container_name: nomis-user-roles-api
+    container_name: mmp-nomis-roles
     ports:
       - '8102:8080'
     healthcheck:
@@ -29,7 +29,7 @@ services:
     image: quay.io/hmpps/hmpps-auth:latest
     networks:
       - hmpps
-    container_name: hmpps-auth
+    container_name: mmp-hmpps-auth
     depends_on: [nomis-user-roles-api]
     ports:
       - '9090:8080'
@@ -45,7 +45,7 @@ services:
     command: server --console-address :9001 /data
     networks:
       - hmpps
-    container_name: minio
+    container_name: mmp-minio
     restart: always
     environment:
       - MINIO_REGION_NAME=eu-west-2
@@ -59,7 +59,7 @@ services:
     image: minio/mc
     networks:
       - hmpps
-    container_name: minio-init
+    container_name: mmp-minio-init
     depends_on:
       - minio
     volumes:
@@ -81,7 +81,7 @@ services:
     build: .
     networks:
       - hmpps
-    container_name: app
+    container_name: mmp
     depends_on:
       - redis
       - hmpps-auth


### PR DESCRIPTION
This is now required by the latest version of the HMPPS Auth service.

[Reference](https://github.com/ministryofjustice/send-legal-mail-to-prisons/pull/59)